### PR TITLE
[BackEnd] UserRole 리팩토링 - STUDIO enum 제거, role 하드코딩

### DIFF
--- a/server/features/dancer/dto/responses.py
+++ b/server/features/dancer/dto/responses.py
@@ -10,7 +10,7 @@ class DancerResponse(BaseModel):
     instagram: Optional[str]
     is_verified: bool
     genre: Optional[str]
-    role: Optional[str]  # User.role.value if user exists
+    role: str
 
     @staticmethod
     def from_dancer(dancer: Dancer) -> "DancerResponse":
@@ -21,7 +21,7 @@ class DancerResponse(BaseModel):
             instagram=dancer.instagram,
             is_verified=dancer.is_verified,
             genre=dancer.genre.value if dancer.genre else None,
-            role=dancer.user.role.value if dancer.user else None
+            role="DANCER"
         )
 
 

--- a/server/features/studio/dto/responses.py
+++ b/server/features/studio/dto/responses.py
@@ -18,7 +18,7 @@ class StudioResponse(BaseModel):
     default_price: Optional[int]
     youtube: Optional[str]
     bio: Optional[str]
-    role: Optional[str]  # User.role.value if user exists
+    role: str
 
     @staticmethod
     def from_studio(studio: Studio) -> "StudioResponse":
@@ -37,5 +37,5 @@ class StudioResponse(BaseModel):
             default_price=studio.default_price,
             youtube=studio.youtube,
             bio=studio.bio,
-            role=studio.user.role.value if studio.user else None
+            role="STUDIO"
         )

--- a/server/features/user/models.py
+++ b/server/features/user/models.py
@@ -16,7 +16,6 @@ import enum
 class UserRole(enum.Enum):
     USER = "user"
     DANCER = "dancer"
-    STUDIO = "studio"
 
 # 유저 정보
 class User(Base):


### PR DESCRIPTION
- UserRole enum에서 STUDIO 제거 (USER, DANCER만 유지)
- 스튜디오 관리자는 Studio.user_id 관계로만 표현
- DancerResponse.role을 "DANCER"로 하드코딩
- StudioResponse.role을 "STUDIO"로 하드코딩
- 댄서가 스튜디오를 운영하거나 관리자 변경 시 유연하게 대응 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)